### PR TITLE
Add EYESY v3 support and Python 3.13 compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+eyesim is a Python simulator for the [eyesy](https://www.critterandguitari.com/eyesy) visual synthesizer. It allows developers to create and test eyesy visualization modes without needing the physical hardware. The simulator provides a pygame window with interactive controls that mimic the eyesy's knobs and buttons.
+
+**Note: eyesim now supports EYESY v3 API** - The simulator has been updated to use the v3 naming conventions (`eyesy` instead of `etc`) and includes new v3 features.
+
+## Development Commands
+
+### Installation and Setup
+```bash
+pip install -e .          # Install in development mode
+pip install eyesim         # Install from PyPI
+```
+
+### Running the Simulator
+```bash
+eyesim --mode-folder test                                    # Run built-in test mode
+eyesim -m "/path/to/mode/" -a "/path/to/audio.wav"         # Run custom mode with audio
+eyesim -m "/path/to/mode/" -w 1920 -t 1080                 # Custom window dimensions
+```
+
+### Testing
+No formal test suite is present. Test modes manually using the built-in test mode or custom mode folders.
+
+## Architecture
+
+### Core Components
+
+- **`runner.py`**: Main entry point and simulation loop. Handles pygame initialization, widget creation, audio processing, and the main game loop.
+- **`etc.py`**: Contains the `System` class that emulates the eyesy hardware environment. Provides knob values, audio data, color utilities, and mode management.
+- **`helpers.py`**: Utility functions for directory operations.
+
+### Mode Structure (EYESY v3)
+
+Modes are Python modules that must implement two functions:
+- `setup(screen, eyesy)`: Initialize the mode (called once)
+- `draw(screen, eyesy)`: Render frame (called every frame at 30 FPS)
+
+The `eyesy` parameter (v3: renamed from `etc`) provides access to:
+- `eyesy.knob1` through `eyesy.knob5`: Knob values (0.0-1.0)
+- `eyesy.audio_in`: Array of 100 audio samples
+- `eyesy.trig`: Audio trigger state (v3: renamed from `audio_trig`)
+- `eyesy.xres`, `eyesy.yres`: Screen dimensions
+- `eyesy.color_picker()`, `eyesy.color_picker_bg()`: Color utilities
+- `eyesy.color_picker_lfo(val, rate)`: New v3 color picker with LFO rate control
+- `eyesy.auto_clear`: Whether to clear screen each frame
+
+### Key Simulator Features
+
+- **Interactive Controls**: Press spacebar to toggle visibility of 5 vertical sliders (simulating knobs) and a persist button (toggles auto_clear)
+- **Audio Processing**: Real-time audio file playback with sample extraction for visualization
+- **Mode Loading**: Dynamic loading of mode folders containing `main.py` files
+- **eyesy API Compatibility**: Maintains compatibility with the eyesy Python 2 API while running on Python 3
+
+### EYESY v3 Migration Notes
+
+**API Changes from v2 to v3:**
+- Parameter name changed from `etc` to `eyesy` in setup() and draw() functions
+- `etc.audio_trig` renamed to `eyesy.trig`
+- Removed `eyesy.lastgrab` and `eyesy.lastgrab_thumb` (no longer available)
+- Added new `eyesy.color_picker_lfo(val, rate=1.0)` function for LFO-modulated colors
+
+**Python 2/3 Compatibility Notes:**
+The simulator runs Python 3 but needs to support eyesy modes written in Python 2. Common issues:
+- Print statements: Use `print("foo")` not `print "foo"`
+- Integer division: Use `//` for integer division or `int(1/2)` for explicit conversion
+
+### Dependencies
+
+- **pygame**: Graphics and window management
+- **pygame_widgets**: UI controls for knob simulation  
+- **scipy**: WAV file reading (requires 16-bit WAV files)
+
+## File Structure
+
+```
+eyesim/
+├── __init__.py          # Empty package init
+├── runner.py            # Main simulation engine and CLI
+├── etc.py              # System class (eyesy hardware emulation)
+├── helpers.py          # Utility functions
+└── test-mode/          # Built-in test mode
+    ├── main.py         # Simple circle visualization
+    └── test.wav        # Test audio file
+```

--- a/eyesim/etc.py
+++ b/eyesim/etc.py
@@ -5,7 +5,7 @@ import random
 import math
 import pygame
 import traceback
-import imp
+import importlib.util
 import os
 import glob
 import sys
@@ -15,6 +15,7 @@ from eyesim import helpers
 
 
 class System:
+    """EYESY v3 compatible system class (replaces 'etc' with 'eyesy' naming)"""
 
     GRABS_PATH = "/sdcard/Grabs/"
     MODES_PATH = "/sdcard/Modes/Python/"
@@ -40,9 +41,7 @@ class System:
     BLUE = (0, 0, 255)
     OSDBG = (0,0,255)
 
-    # screen grabs
-    lastgrab = None
-    lastgrab_thumb = None
+    # screen grabs - v3: removed lastgrab and lastgrab_thumb
     tengrabs_thumbs = []
     grabcount = 0
     grabindex = 0
@@ -66,7 +65,7 @@ class System:
     # audio
     audio_in = [0] * 100
     audio_peak = 0
-    audio_trig = False
+    trig = False  # v3: renamed from audio_trig
     audio_scale = 1.0
     audio_trig_enable = True
    
@@ -112,7 +111,7 @@ class System:
 
     def update_trig_button(self, stat) :
         if (stat > 0 ):
-            self.audio_trig = True
+            self.trig = True  # v3: renamed from audio_trig
             self.trig_button = True
         else :
             self.trig_button = False
@@ -214,12 +213,10 @@ class System:
         pygame.image.save(self.screen,imagepath)
         # make sure it is saved as 'music' user, uid=gid=1000
         os.chown(imagepath, 1000, 1000)
-        # add to the grabs array
+        # add to the grabs array - v3: removed lastgrab references
         self.grabindex += 1
         self.grabindex %= 5
         pygame.transform.scale(self.screen, (128, 72), self.tengrabs_thumbs[self.grabindex] )
-        self.lastgrab = self.screen.copy()
-        self.lastgrab_thumb = self.tengrabs_thumbs[self.grabindex]
         print("grabbed " + imagepath)
 
     # load modes,  check if modes are found
@@ -233,7 +230,10 @@ class System:
             mode_path = self.MODES_PATH+mode_name+'/main.py'
             print(mode_path)
             try :
-                imp.load_source(mode_name, mode_path)
+                # v3: Replace deprecated imp.load_source with importlib
+                spec = importlib.util.spec_from_file_location(mode_name, mode_path)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
                 self.mode_names.append(mode_name)
                 got_a_mode = True
             except Exception as e:
@@ -245,7 +245,10 @@ class System:
         print("loadeing new mode "+new_mode+"...")
         mode_path = self.MODES_PATH+new_mode+'/main.py'
         try :
-            imp.load_source(new_mode, mode_path)
+            # v3: Replace deprecated imp.load_source with importlib
+            spec = importlib.util.spec_from_file_location(new_mode, mode_path)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
             self.mode_names.append(new_mode)
         except Exception as e:
             print(traceback.format_exc())
@@ -259,7 +262,11 @@ class System:
             del(sys.modules[self.mode]) 
         print("deleted module, reloading")
         try :
-            imp.load_source(self.mode, self.mode_root+'/main.py')
+            # v3: Replace deprecated imp.load_source with importlib
+            spec = importlib.util.spec_from_file_location(self.mode, self.mode_root+'/main.py')
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            sys.modules[self.mode] = module
             print("reloaded")
         except Exception as e:
             self.error = traceback.format_exc()
@@ -274,16 +281,12 @@ class System:
         # make sure it is saved as 'music' user, uid=gid=1000
         os.chown(self.GRABS_PATH, 1000, 1000)
         print('loading recent grabs...')
-        self.lastgrab = None
-        self.lastgrab_thumb = None
+        # v3: removed lastgrab and lastgrab_thumb initialization
         self.tengrabs_thumbs = []
         self.grabcount = 0
         self.grabindex = 0
         for i in range(0,11):
             self.tengrabs_thumbs.append(pygame.Surface((128, 72)))
-        
-        self.lastgrab = pygame.Surface(self.RES )
-        self.lastgrab_thumb = pygame.Surface((128,72) )
 
         for filepath in sorted(glob.glob(self.GRABS_PATH + '*.jpg')):
             try :
@@ -292,8 +295,7 @@ class System:
                 img = pygame.image.load(filepath)
                 img = img.convert()
                 thumb = pygame.transform.scale(img, (128, 72) )
-                self.lastgrab = img
-                self.lastgrab_thumb = thumb
+                # v3: removed lastgrab assignments
                 self.tengrabs_thumbs[self.grabcount] = thumb
                 self.grabcount += 1
             except Exception as e:
@@ -339,7 +341,7 @@ class System:
 
     def write_all_scenes(self):
 	    # write it
-        with open(self.SCENES_PATH, "wb") as f:
+        with open(self.SCENES_PATH, "w", newline='') as f:
     	    writer = csv.writer(f,quoting=csv.QUOTE_MINIMAL)
     	    writer.writerows(self.scenes) 
         #print("saved scenes: " + str(self.scenes))
@@ -349,12 +351,12 @@ class System:
     def load_scenes(self):
         # create scene file if doesn't exits
         if not os.path.exists(self.SCENES_PATH):
-            f = file(self.SCENES_PATH, "w")
-            f.close()
+            with open(self.SCENES_PATH, "w") as f:
+                pass
         # make sure it is saved as 'music' user, uid=gid=1000
         os.chown(self.SCENES_PATH, 1000, 1000)
         # open it
-        with open(self.SCENES_PATH, 'rb') as f:
+        with open(self.SCENES_PATH, 'r', newline='') as f:
             reader = csv.reader(f)
             csvin = list(reader)
         self.scenes = []
@@ -462,6 +464,18 @@ class System:
         
         color2 = (color[0], color[1], color[2])
         return color2
+
+    def color_picker_lfo(self, val, rate=1.0):
+        """v3: New color picker with LFO rate control"""
+        import time
+        # Use frame count or time for LFO
+        lfo_time = self.frame_count * rate * 0.01  # Adjust multiplier as needed
+        
+        # Modulate the input value with LFO
+        lfo_val = math.sin(lfo_time) * 0.1 + val
+        lfo_val = max(0.0, min(1.0, lfo_val))  # Clamp to 0-1
+        
+        return self.color_picker(lfo_val)
  
     def color_picker_bg( self, val):
         c = float(val)
@@ -476,7 +490,7 @@ class System:
 
     def clear_flags(self):
         self.new_midi = False
-        self.audio_trig = False
+        self.trig = False  # v3: renamed from audio_trig
         self.run_setup = False
         self.screengrab_flag = False
         self.midi_note_new = False

--- a/eyesim/runner.py
+++ b/eyesim/runner.py
@@ -78,17 +78,17 @@ def run(
         widget.hide()
     widgets_hidden = True
 
-    # Set up etc...
+    # Set up eyesy (v3: renamed from etc)...
 
-    etc = eyesim.etc.System()
-    etc.mode_root = str(mode_folder.absolute())
-    etc.xres = width
-    etc.yres = height
+    eyesy = eyesim.etc.System()
+    eyesy.mode_root = str(mode_folder.absolute())
+    eyesy.xres = width
+    eyesy.yres = height
     for i in range(5):
-        setattr(etc, f"knob{i+1}", 0.5)
-    mode.setup(screen, etc)
+        setattr(eyesy, f"knob{i+1}", 0.5)
+    mode.setup(screen, eyesy)
     persist_button.onClick = lambda: setattr(
-        etc, 'auto_clear', not etc.auto_clear
+        eyesy, 'auto_clear', not eyesy.auto_clear
     )
 
     # Set up audio if applicable...
@@ -142,20 +142,23 @@ def run(
                     widgets_hidden = not widgets_hidden
 
             if has_audio:
-                etc.audio_in = get_audio_segment()
+                eyesy.audio_in = get_audio_segment()
 
             if not widgets_hidden:
                 for i, slider in enumerate(sliders, start=1):
                     value = slider.getValue() / 100.0
-                    setattr(etc, f"knob{i}", value)
+                    setattr(eyesy, f"knob{i}", value)
 
-            # Updates, draw, etc.
-            mode.draw(screen, etc)
+            # Updates, draw, eyesy (v3: renamed parameter)
+            mode.draw(screen, eyesy)
             pygame_widgets.update(events)
             pygame.display.update()
-            if etc.auto_clear:
-                screen.fill(etc.bg_color)
+            if eyesy.auto_clear:
+                screen.fill(eyesy.bg_color)
 
+            # Update frame count for v3 features like color_picker_lfo
+            eyesy.frame_count += 1
+            
             clock.tick(30)
     except KeyboardInterrupt:
         shutdown()

--- a/eyesim/test-mode/main.py
+++ b/eyesim/test-mode/main.py
@@ -1,18 +1,30 @@
 import pygame
 
 
-def setup(screen, etc):
+def setup(screen, eyesy):
+    """v3: Changed parameter name from 'etc' to 'eyesy'"""
     pass
 
 
-def draw(screen, etc):
-    xmid = etc.xres // 2
-    ymid = etc.yres // 2
+def draw(screen, eyesy):
+    """v3: Changed parameter name from 'etc' to 'eyesy'"""
+    xmid = eyesy.xres // 2
+    ymid = eyesy.yres // 2
+    
+    # Demonstrate v3 features: use color_picker_lfo for dynamic colors
+    if eyesy.knob4 < 0.5:
+        # Traditional color picker
+        color = eyesy.color_picker(eyesy.knob1)
+    else:
+        # v3: New color_picker_lfo with rate control
+        lfo_rate = (eyesy.knob4 - 0.5) * 4.0  # 0 to 2.0 range
+        color = eyesy.color_picker_lfo(eyesy.knob1, lfo_rate)
+    
     pygame.draw.circle(
         surface=screen,
-        color=etc.color_picker(etc.knob1), 
+        color=color, 
         center=(xmid, ymid),
-        radius=10*etc.knob2 * max(etc.audio_in) / 2**8,
-        width=int(10*etc.knob3),
+        radius=10*eyesy.knob2 * max(eyesy.audio_in) / 2**8,
+        width=int(10*eyesy.knob3),
     )
-    etc.color_picker_bg(etc.knob5)
+    eyesy.color_picker_bg(eyesy.knob5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pygame==2.1.2
-pygame_widgets==1.0.0
-scipy==1.8.1
+pygame>=2.1.2
+pygame_widgets>=1.0.0
+scipy>=1.9.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
         name="eyesim",
         packages=find_packages(),
         install_requires=open("requirements.txt").read().strip().split("\n"),
-        version="0.0.1",
+        version="0.1.0",  # Updated for EYESY v3 support
         entry_points={
             "console_scripts": ["eyesim = eyesim.runner:run_cli"]
         }


### PR DESCRIPTION
- Update API naming from 'etc' to 'eyesy' parameter in mode functions
- Rename audio_trig to trig for v3 compatibility
- Remove deprecated lastgrab and lastgrab_thumb attributes
- Add new color_picker_lfo() function with LFO rate control
- Replace deprecated imp module with importlib for Python 3.13
- Update Python 2 file() calls to use open() context managers
- Fix CSV file handling for Python 3 text mode
- Update dependencies to support modern Python versions
- Enhance test mode to demonstrate v3 features
- Update version to 0.1.0 reflecting v3 support
- Add comprehensive documentation in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.ai/code)